### PR TITLE
change pass_defaults to do a deep merge, enabling HTTP basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,14 @@ This module also contains some helper functions for adding strings and JSON to I
 Use an IPFS server with basic auth (replace username and password with real creds):
 
 ```py
->>> import base64
 >>> import ipfshttpclient
->>> creds = base64.b64encode(b"username:password").decode("utf-8")
->>> headers = {"Authorization" : "Basic " + creds}
+>>> api = ipfshttpclient.connect('/dns/ipfs-api.example.com/tcp/443/https', username="foo", password="bar")
+```
+
+Pass custom headers to your IPFS api with each request:
+```py
+>>> import ipfshttpclient
+>>> headers = {"CustomHeader": "foobar"}
 >>> api = ipfshttpclient.connect('/dns/ipfs-api.example.com/tcp/443/https', headers=headers)
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ This module also contains some helper functions for adding strings and JSON to I
 [1, 77, 'lol']
 ```
 
+Use an IPFS server with basic auth (replace username and password with real creds):
+
+```py
+>>> import base64
+>>> import ipfsapi
+>>> creds = base64.b64encode(b"username:password").decode("utf-8")
+>>> headers = {"Authorization" : "Basic " + creds}
+>>> api = ipfsapi.connect('https://ipfs-api.example.com', 443, headers=headers)
+```
+
+
+
 ## Documentation
 
 Documentation (currently mostly API documentation unfortunately) is available on IPFS:

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ Use an IPFS server with basic auth (replace username and password with real cred
 
 ```py
 >>> import base64
->>> import ipfsapi
+>>> import ipfshttpclient
 >>> creds = base64.b64encode(b"username:password").decode("utf-8")
 >>> headers = {"Authorization" : "Basic " + creds}
->>> api = ipfsapi.connect('https://ipfs-api.example.com', 443, headers=headers)
+>>> api = ipfshttpclient.connect('/dns/ipfs-api.example.com/tcp/443/https', headers=headers)
 ```
 
 

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -96,8 +96,9 @@ def connect(addr=DEFAULT_ADDR, base=DEFAULT_BASE,
 		:class:`~ipfshttpclient.Client`
 	"""
 	if username is not None:
-		creds = base64.b64encode(f'{username}:{"" if password is None else password}'.encode()).decode("utf-8")
-		args = {"headers": {"Authorization": "Basic " + creds}}
+		creds = '{0}:{1}'.format(username, "" if password is None else password)
+		encoded_creds = base64.b64encode(creds.encode()).decode("utf-8")
+		args = {"headers": {"Authorization": "Basic " + encoded_creds}}
 		defaults = utils.deep_update(defaults, args)
 
 	# Create client instance

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 
 import os
 import warnings
-
+import base64
 import multiaddr
 
 DEFAULT_ADDR = multiaddr.Multiaddr(os.environ.get("PY_IPFS_HTTP_CLIENT_DEFAULT_ADDR", '/dns/localhost/tcp/5001/http'))
@@ -73,7 +73,7 @@ def assert_version(version, minimum=VERSION_MINIMUM, maximum=VERSION_MAXIMUM, bl
 
 def connect(addr=DEFAULT_ADDR, base=DEFAULT_BASE,
             chunk_size=multipart.default_chunk_size,
-            session=False, **defaults):
+            session=False, username=None, password=None, **defaults):
 	"""Create a new :class:`~ipfshttpclient.Client` instance and connect to the
 	daemon to validate that its version is supported.
 
@@ -88,12 +88,18 @@ def connect(addr=DEFAULT_ADDR, base=DEFAULT_BASE,
 
 
 	All parameters are identical to those passed to the constructor of the
-	:class:`~ipfshttpclient.Client` class.
+	:class:`~ipfshttpclient.Client` class, except username and password,
+	which are converted to a 'headers' keyword argument.
 
 	Returns
 	-------
 		:class:`~ipfshttpclient.Client`
 	"""
+	if username is not None:
+		creds = base64.b64encode(f'{username}:{"" if password is None else password}'.encode()).decode("utf-8")
+		args = {"headers": {"Authorization": "Basic " + creds}}
+		defaults = utils.deep_update(defaults, args)
+
 	# Create client instance
 	client = Client(addr, base, chunk_size, session, **defaults)
 

--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 import abc
 import functools
 import tarfile
-import collections
 from six.moves import http_client
 import os
 import socket

--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 import abc
 import functools
 import tarfile
+import collections
 from six.moves import http_client
 import os
 import socket
@@ -32,6 +33,15 @@ else:  # pragma: no cover (always enabled in production)
 	import requests
 
 
+def deep_update(d, u):
+    for k, v in u.items():
+        if isinstance(v, collections.Mapping):
+            d[k] = deep_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
+
 def pass_defaults(func):
 	"""Decorator that returns a function named wrapper.
 
@@ -45,8 +55,8 @@ def pass_defaults(func):
 	@functools.wraps(func)
 	def wrapper(self, *args, **kwargs):
 		merged = {}
-		merged.update(self.defaults)
-		merged.update(kwargs)
+		merged = deep_update(merged, self.defaults)
+		merged = deep_update(merged, kwargs)
 		return func(self, *args, **merged)
 	return wrapper
 

--- a/ipfshttpclient/http.py
+++ b/ipfshttpclient/http.py
@@ -25,21 +25,13 @@ import six
 
 from . import encoding
 from . import exceptions
+from . import utils
 PATCH_REQUESTS = (os.environ.get("PY_IPFS_HTTP_CLIENT_PATCH_REQUESTS", "yes").lower()
                   not in ("false", "no"))
 if PATCH_REQUESTS:
 	from . import requests_wrapper as requests
 else:  # pragma: no cover (always enabled in production)
 	import requests
-
-
-def deep_update(d, u):
-    for k, v in u.items():
-        if isinstance(v, collections.Mapping):
-            d[k] = deep_update(d.get(k, {}), v)
-        else:
-            d[k] = v
-    return d
 
 
 def pass_defaults(func):
@@ -55,8 +47,8 @@ def pass_defaults(func):
 	@functools.wraps(func)
 	def wrapper(self, *args, **kwargs):
 		merged = {}
-		merged = deep_update(merged, self.defaults)
-		merged = deep_update(merged, kwargs)
+		merged = utils.deep_update(merged, self.defaults)
+		merged = utils.deep_update(merged, kwargs)
 		return func(self, *args, **merged)
 	return wrapper
 

--- a/ipfshttpclient/utils.py
+++ b/ipfshttpclient/utils.py
@@ -8,7 +8,6 @@ try:  #PY3
 except ImportError:  #PY2: The relevant classes used to be somewhere else
 	class collections:
 		import collections as abc
-import collections
 import mimetypes
 import os
 import six

--- a/ipfshttpclient/utils.py
+++ b/ipfshttpclient/utils.py
@@ -8,6 +8,7 @@ try:  #PY3
 except ImportError:  #PY2: The relevant classes used to be somewhere else
 	class collections:
 		import collections as abc
+import collections
 import mimetypes
 import os
 import six
@@ -35,7 +36,7 @@ else:  #PY35
 		path_obj_types += (pathlib2.PurePath,)
 	except ImportError:
 		pass
-	
+
 	def convert_path(path):
 		# `pathlib`'s PathLike objects need to be treated specially and
 		# converted to strings when interacting with system APIs
@@ -142,3 +143,14 @@ class return_field(object):
 			res = cmd(*args, **kwargs)
 			return res[self.field]
 		return wrapper
+
+
+def deep_update(d, u):
+	""" Performs a deep recursive merge/update of u into d.
+	"""
+	for k, v in u.items():
+		if isinstance(v, collections.Mapping):
+			d[k] = deep_update(d.get(k, {}), v)
+		else:
+			d[k] = v
+	return d

--- a/ipfshttpclient/utils.py
+++ b/ipfshttpclient/utils.py
@@ -148,7 +148,7 @@ def deep_update(d, u):
 	""" Performs a deep recursive merge/update of u into d.
 	"""
 	for k, v in u.items():
-		if isinstance(v, collections.Mapping):
+		if isinstance(v, collections.abc.Mapping):
 			d[k] = deep_update(d.get(k, {}), v)
 		else:
 			d[k] = v


### PR DESCRIPTION
Fixes #154 

Enables basic auth and many other use cases by "deep merging" the defaults dict instead of using `dict.update` which overwrites previously seen keys (such as `headers`).

I do see that @alexander255 and @AliabbasMerchant are doing a lot of new work and reorganization on the py-ipfs-http-client branch. This change would be very simple to add to that branch as well.