### PR TITLE
bug fix: when storing large amounts of text or bytes the data would b…

### DIFF
--- a/ipfshttpclient/multipart.py
+++ b/ipfshttpclient/multipart.py
@@ -185,7 +185,7 @@ class StreamBase(object):
 		for data in gen:
 			#PERF: This is zero-copy if `len(data) <= self.chunk_size`
 			for offset in range(0, len(data), self.chunk_size):
-				yield data[offset:self.chunk_size]
+				yield data[offset:self.chunk_size+offset]
 
 	def _gen_item_start(self):
 		"""Yields the body section for the content.


### PR DESCRIPTION
…e truncated

Problem was because in the generator StreamBase._gen_chunks() the second parameter in the data slice was not incremented with the offset.
Because of this only the first chunk was yielded correctly.