### PR TITLE
typo in README.md regarding client.pin.ls example?

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Administrative functions:
 Pass in API options:
 
 ```py
->>> client.pin_ls(type='all')
+>>> client.pin.ls(type='all')
 {'Keys': {'QmNMELyizsfFdNZW3yKTi1SE2pErifwDTXx6vvQBfwcJbU': {'Count': 1,
                                                              'Type': 'indirect'},
           'QmNQ1h6o1xJARvYzwmySPsuv9L5XfzS4WTvJSTAWwYRSd8': {'Count': 1,


### PR DESCRIPTION
The example states "client.pin_ls(...", but the correct form seems to be "client.pin.ls(..."