### PR TITLE
Update versions for 0.6.0 release (synchronize with PyPI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ dist: bionic  # VirtualEnv is too old on xenial
 
 matrix:
    include:
-      - python: "3.5"
-      - python: "3.6"
       - python: "3.7"
       - python: "3.8"
       - python: "pypy3"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Check out [the HTTP Client reference](https://ipfs.io/ipns/12D3KooWEqnTdgqHnkkwa
 See the [relevant section of the README](#important-changes-from-ipfsapi-04x) for details.
 
 **Note:** This library occasionally has to change to stay compatible with the IPFS HTTP API.
-Currently, this library is tested against [go-ipfs v0.5.0-rc2](https://github.com/ipfs/go-ipfs/releases/tag/v0.5.0-rc2).
+Currently, this library is tested against [go-ipfs v0.6.0](https://github.com/ipfs/go-ipfs/releases/tag/v0.6.0).
 We strive to support the last 5 releases of go-IPFS at any given time; go-IPFS v0.4.21 therefore
 being to oldest supported version at this time (version 0.4.20 was never supported due to major
 issues in the daemon itself).

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -15,7 +15,7 @@ DEFAULT_BASE = str(os.environ.get("PY_IPFS_HTTP_CLIENT_DEFAULT_BASE", 'api/v0'))
 
 VERSION_MINIMUM   = "0.4.21"
 VERSION_BLACKLIST = []
-VERSION_MAXIMUM   = "0.6.0"
+VERSION_MAXIMUM   = "0.7.0"
 
 from . import bitswap
 from . import block

--- a/ipfshttpclient/version.py
+++ b/ipfshttpclient/version.py
@@ -8,4 +8,4 @@
 # `0.4.1` and so on. When IPFS `0.5.0` is released, the first client version
 # to support it will also be released as `0.5.0`.
 
-__version__ = "0.4.13.2"
+__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords     = "ipfs storage distribution development"
 license      = "MIT License"
 description-file = "README.md"
 
-requires-python = ">=3.5"
+requires-python = ">=3.7"
 requires = [
 	"multiaddr (>=0.0.7)",
 	"requests (>=2.11)"
@@ -37,8 +37,6 @@ classifiers = [
 	# Specify the Python versions you support here. In particular, ensure
 	# that you indicate whether you support Python 2, Python 3 or both.
 	"Programming Language :: Python :: 3 :: Only",
-	"Programming Language :: Python :: 3.5",
-	"Programming Language :: Python :: 3.6",
 	"Programming Language :: Python :: 3.7",
 	"Programming Language :: Python :: 3.8"
 ]


### PR DESCRIPTION
Synchronize with the tarball that has been released on PyPI under a new name: ipfshttpclient4ipwb 0.6.0
I think what's missing is after merging this PR tag the master with 0.6.0, release it on github, and upload as a new release to pypi ipfshttpclient package (and perhaps delete ipfshttpclient4ipwb from PyPI to avoid confusion).