### PR TITLE
test: print connection error

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -21,6 +21,7 @@ def is_available():  # noqa
 		try:
 			ipfshttpclient.connect()
 		except ipfshttpclient.exceptions.Error as error:
+			print("Failed to connect to IPFS daemon:", error)
 			__is_available = False
 			
 			# Make sure version incompatibility is displayed to users


### PR DESCRIPTION
To provide reason for failure when running tests.

Note: to see stderr/stdout from tests: ./run-tests.py --capture=no