### PR TITLE
Add support for connecting to the IPFS daemon over Unix domain sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bugfixes:
 
  * The value of the `timeout` parameter on `ipfshttpclient.{connect,Client}` is no longer ignored when using the `requests` HTTP backend (default)
     * (The per-API-call `timeout` parameter was unaffected by this.)
+ * The HTTPx HTTP backend now properly applies address family restrictions encoded as part of the daemon MultiAddr (needed minor upstream change)
 
 py-ipfs-http-client 0.6.0 (30.06.2020)
 --------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 py-ipfs-http-client 0.6.1 (XX.XX.20XX)
 --------------------------------------
 
- * Add typings for most of the public and private API and enable type checking with `mypy`
+ * Added typings for most of the public and private API and enable type checking with `mypy`
+ * Added support for connecting to the IPFS daemon using Unix domain sockets (implemented for both the requests and HTTPx backend)
  * Deprecate `.repo.gc(…)`s `return_result` parameter in favour of the newly introduced `quiet` parameter to match the newer HTTP API
  * If you use the undocumented `return_result` parameter anywhere else consider such use deprecated, support for this parameter will be removed in 0.7.X everywhere
+    * Rationale: This parameter used to map to using the HTTP HEAD method perform the given request without any reply being returned, but this feature has been dropped with go-IPFS 0.5 from the API.
 
 Bugfixes:
 

--- a/README.md
+++ b/README.md
@@ -157,11 +157,17 @@ Use an IPFS server with basic auth (replace username and password with real cred
 >>> client = ipfshttpclient.connect('/dns/ipfs-api.example.com/tcp/443/https', auth=("username", "password"))
 ```
 
-Pass custom headers to your IPFS api with each request:
+Pass custom headers to the IPFS daemon with each request:
 ```py
 >>> import ipfshttpclient
 >>> headers = {"CustomHeader": "foobar"}
 >>> client = ipfshttpclient.connect('/dns/ipfs-api.example.com/tcp/443/https', headers=headers)
+```
+
+Connect to the IPFS daemon using a Unix domain socket (plain HTTP only):
+```py
+>>> import ipfshttpclient
+>>> client = ipfshttpclient.connect("/unix/run/ipfs/ipfs.sock")
 ```
 
 

--- a/ipfshttpclient/http_requests.py
+++ b/ipfshttpclient/http_requests.py
@@ -71,8 +71,9 @@ def map_args_to_requests(
 
 
 class ClientSync(ClientSyncBase[requests.Session]):  # type: ignore[name-defined]
-	__slots__ = ("_base_url", "_session_props", "_default_timeout")
+	__slots__ = ("_base_url", "_default_timeout", "_session_props")
 	#_base_url: str
+	#_default_timeout: timeout_t
 	#_session_props: ty.Dict[str, ty.Any]
 	
 	def _init(self, addr: addr_t, base: str, *,  # type: ignore[no-any-unimported]
@@ -81,7 +82,7 @@ class ClientSync(ClientSyncBase[requests.Session]):  # type: ignore[name-defined
 	          headers: headers_t,
 	          params: params_t,
 	          timeout: timeout_t) -> None:
-		self._base_url, family, host_numeric = multiaddr_to_url_data(addr, base)
+		self._base_url, _, family, host_numeric = multiaddr_to_url_data(addr, base)
 		
 		self._session_props = map_args_to_requests(
 			auth=auth,

--- a/test/unit/test_http_httpx.py
+++ b/test/unit/test_http_httpx.py
@@ -47,10 +47,10 @@ cookiejar = http.cookiejar.CookieJar()
 def test_map_args_to_httpx(kwargs, expected):
 	assert ipfshttpclient.http_httpx.map_args_to_httpx(**kwargs) == expected
 
-@pytest.mark.parametrize("args,kwargs,expected_kwargs,expected_base", [
+@pytest.mark.parametrize("args,kwargs,expected_kwargs,expected_base,expected_laddr", [
 	(("/dns/localhost/tcp/5001/http", "api/v0"), {}, {
 		"params": [("stream-channels", "true")],
-	}, "http://localhost:5001/api/v0/"),
+	}, "http://localhost:5001/api/v0/", None),
 	
 	(("/dns6/ietf.org/tcp/443/https", "/base/"), {
 		"auth": ("user", "pass"),
@@ -59,15 +59,15 @@ def test_map_args_to_httpx(kwargs, expected):
 		"offline": True,
 		"timeout": (math.inf, math.inf),
 	}, {
-		#XXX: This should also store the expected address family somewhere
 		"auth": ("user", "pass"),
 		"cookies": cookiejar,
 		"headers": {"name": "value"},
 		"params": [("offline", "true"), ("stream-channels", "true")],
 		"timeout": (None, None, None, None),
-	}, "https://ietf.org:443/base/"),
+	}, "https://ietf.org:443/base/", "::"),
 ])
-def test_client_args_to_session_kwargs(args, kwargs, expected_kwargs, expected_base):
+def test_client_args_to_session_kwargs(args, kwargs, expected_kwargs, expected_base, expected_laddr):
 	client = ipfshttpclient.http_httpx.ClientSync(*args, **kwargs)
 	assert client._session_kwargs == expected_kwargs
 	assert client._session_base == expected_base
+	assert client._session_laddr == expected_laddr

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 minversion = 3.3
 envlist =
 	py3,
-	pypy3,
+	py3-httpx,
 	styleck,
 	typeck
 
@@ -45,7 +45,7 @@ deps =
 [testenv:py3-httpx]
 deps =
 	{[testenv]deps}
-	httpx (~=0.13.0)
+	httpx (~=0.14.0)  # Including its httpcore 0.10.* dependency
 setenv =
 	{[testenv]setenv}
 	PY_IPFS_HTTP_CLIENT_PREFER_HTTPX = yes
@@ -69,7 +69,7 @@ skip_install = true
 deps =
 	mypy ~= 0.782
 	pytest ~= 5.0
-	httpx ~= 0.13.0
+	httpx ~= 0.14.0
 commands =
 	mypy --config-file=tox.ini {posargs} -p ipfshttpclient
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,9 +43,12 @@ deps =
 
 
 [testenv:py3-httpx]
+deps-exclusive =
+	httpx    (~= 0.14.0)
+	httpcore (~= 0.10.2)  # Has Unix domain socket support
 deps =
 	{[testenv]deps}
-	httpx (~=0.14.0)  # Including its httpcore 0.10.* dependency
+	{[testenv:py3-httpx]deps-exclusive}
 setenv =
 	{[testenv]setenv}
 	PY_IPFS_HTTP_CLIENT_PREFER_HTTPX = yes
@@ -69,7 +72,7 @@ skip_install = true
 deps =
 	mypy ~= 0.782
 	pytest ~= 5.0
-	httpx ~= 0.14.0
+	{[testenv:py3-httpx]deps-exclusive}
 commands =
 	mypy --config-file=tox.ini {posargs} -p ipfshttpclient
 


### PR DESCRIPTION
Implements #197 for both HTTPx and requests (and this may well be the last time I do something for that “backend” – can't wait to do the switch in 0.7.x).