### PR TITLE
Update __init__.py

### DIFF
--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -16,7 +16,7 @@ DEFAULT_BASE = str(os.environ.get("PY_IPFS_HTTP_CLIENT_DEFAULT_BASE", 'api/v0'))
 
 VERSION_MINIMUM   = "0.4.22"
 VERSION_BLACKLIST = []
-VERSION_MAXIMUM   = "0.7.0"
+VERSION_MAXIMUM   = "0.7.1"
 
 from . import bitswap
 from . import block


### PR DESCRIPTION
Since the current release version of the IPFS daemon is 0.7.0 and VERSION_MAXIMUM uses a < operator, there is a version mismatch error (see bugs #239 and #240 ). Simplest fix is bumping max to 0.7.1