### PR TITLE
Change exceptions.VersionMismatch into warning

### DIFF
--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -66,12 +66,12 @@ def assert_version(version: str, minimum: str = VERSION_MINIMUM,
 	maximum = list(map(int, maximum.split('-', 1)[0].split('.')))
 
 	if minimum > version or version >= maximum:
-		raise exceptions.VersionMismatch(version, minimum, maximum)
-	
+		warnings.warn(exceptions.VersionMismatch(version, minimum, maximum))
+
 	for blacklisted in blacklist:
 		blacklisted = list(map(int, blacklisted.split('-', 1)[0].split('.')))
 		if version == blacklisted:
-			raise exceptions.VersionMismatch(version, minimum, maximum)
+			warnings.warn(exceptions.VersionMismatch(version, minimum, maximum))
 
 
 def connect(
@@ -97,7 +97,6 @@ def connect(
 	
 	Raises
 	------
-		~ipfshttpclient.exceptions.VersionMismatch
 		~ipfshttpclient.exceptions.ErrorResponse
 		~ipfshttpclient.exceptions.ConnectionError
 		~ipfshttpclient.exceptions.ProtocolError

--- a/ipfshttpclient/exceptions.py
+++ b/ipfshttpclient/exceptions.py
@@ -1,8 +1,10 @@
 """
 The class hierachy for exceptions is::
 
+	Warning
+	 └── VersionMismatch
+
 	Error
-	 ├── VersionMismatch
 	 ├── AddressError
 	 ├── EncoderError
 	 │    ├── EncoderMissingError
@@ -38,7 +40,7 @@ class AddressError(Error, multiaddr.exceptions.Error):  # type: ignore[no-any-un
 		Error.__init__(self, "Unsupported Multiaddr pattern: {0!r}".format(addr))
 
 
-class VersionMismatch(Error):
+class VersionMismatch(Warning):
 	"""Raised when daemon version is not supported by this client version."""
 	__slots__ = ("current", "minimum", "maximum")
 	#current: ty.Sequence[int]

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -22,10 +22,6 @@ def is_available():  # noqa
 			ipfshttpclient.connect()
 		except ipfshttpclient.exceptions.Error as error:
 			__is_available = False
-			
-			# Make sure version incompatibility is displayed to users
-			if isinstance(error, ipfshttpclient.exceptions.VersionMismatch):
-				raise
 		else:
 			__is_available = True
 

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -1,23 +1,51 @@
+import warnings
+
 import pytest
 
 import ipfshttpclient
 
 
 def test_assert_version():
-	# Minimum required version
-	ipfshttpclient.assert_version("0.1.0", "0.1.0", "0.2.0", ["0.1.2"])
-	
+	with warnings.catch_warnings(record=True) as w:
+		# Cause all warnings to always be triggered.
+		warnings.simplefilter("always")
+
+		# Minimum required version
+		ipfshttpclient.assert_version("0.1.0", "0.1.0", "0.2.0", ["0.1.2"])
+
+		assert len(w) == 0
+
 	# Too high version
-	with pytest.raises(ipfshttpclient.exceptions.VersionMismatch):
+	with warnings.catch_warnings(record=True) as w:
+		# Cause all warnings to always be triggered.
+		warnings.simplefilter("always")
+
 		ipfshttpclient.assert_version("0.2.0", "0.1.0", "0.2.0", ["0.1.2"])
-	
+
+		assert len(w) == 1
+		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
+
+
 	# Too low version
-	with pytest.raises(ipfshttpclient.exceptions.VersionMismatch):
+	with warnings.catch_warnings(record=True) as w:
+		# Cause all warnings to always be triggered.
+		warnings.simplefilter("always")
+
 		ipfshttpclient.assert_version("0.0.5", "0.1.0", "0.2.0", ["0.1.2"])
-	
+
+		assert len(w) == 1
+		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
+
+
 	# Blacklisted version
-	with pytest.raises(ipfshttpclient.exceptions.VersionMismatch):
+	with warnings.catch_warnings(record=True) as w:
+		# Cause all warnings to always be triggered.
+		warnings.simplefilter("always")
+
 		ipfshttpclient.assert_version("0.1.2-1", "0.1.0", "0.2.0", ["0.1.2"])
+
+		assert len(w) == 1
+		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
 
 
 def test_client_session_param():


### PR DESCRIPTION
Let users decide whether they’re willing to take the risk; most of IPFS’ API doesn’t change between versions.

This will effectively allow users to use IPFS 0.8, at their own risk. Addresses #252, #250, #234
In addition, this will enable users to help with testing new versions.

I was unable to run tests locally and the tests in the default branch are broken. Manual evaluation of CI test results is required.