### PR TITLE
Fix httpcore dependency; fix style linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /.project
 /.settings
 /.vscode
+/venv
 
 # Stuff that never was meant to be public
 /+junk

--- a/ipfshttpclient/encoding.py
+++ b/ipfshttpclient/encoding.py
@@ -105,8 +105,9 @@ class Json(Encoding[utils.json_value_t]):
 		self._decoder2  = json.JSONDecoder()
 		self._lasterror = None  # type: ty.Optional[ValueError]
 	
-	@ty.no_type_check  # It works just fine and I don't want to rewrite it just
-	                   # because mypy doesn't understand…  # noqa: E114, E116
+	# It works just fine and I don't want to rewrite it just because mypy doesn't understand…
+	# noqa: E114, E116
+	@ty.no_type_check
 	def parse_partial(self, data: bytes) -> ty.Generator[utils.json_value_t, ty.Any, ty.Any]:
 		"""Incrementally decodes JSON data sets into Python objects.
 		

--- a/ipfshttpclient/encoding.py
+++ b/ipfshttpclient/encoding.py
@@ -106,7 +106,6 @@ class Json(Encoding[utils.json_value_t]):
 		self._lasterror = None  # type: ty.Optional[ValueError]
 	
 	# It works just fine and I don't want to rewrite it just because mypy doesn't understand…
-	# noqa: E114, E116
 	@ty.no_type_check
 	def parse_partial(self, data: bytes) -> ty.Generator[utils.json_value_t, ty.Any, ty.Any]:
 		"""Incrementally decodes JSON data sets into Python objects.

--- a/ipfshttpclient/filescanner.py
+++ b/ipfshttpclient/filescanner.py
@@ -512,7 +512,7 @@ class walk(ty.Generator[FSNodeEntry, ty.Any, None], ty.Generic[ty.AnyStr]):
 			#
 			# Note: `os.fwalk` support for binary paths was only added in 3.7+.
 			directory_str_or_fd = directory_str  # type: ty.Union[ty.AnyStr, int]
-			if HAVE_FWALK and (not isinstance(directory_str, bytes) or HAVE_FWALK_BYTES):  # noqa: E501
+			if HAVE_FWALK and (not isinstance(directory_str, bytes) or HAVE_FWALK_BYTES):
 				self._close_fd = directory_str_or_fd = os.open(directory_str, os.O_RDONLY | O_DIRECTORY)
 			
 			self._generator = self._walk(

--- a/ipfshttpclient/filescanner.py
+++ b/ipfshttpclient/filescanner.py
@@ -512,7 +512,7 @@ class walk(ty.Generator[FSNodeEntry, ty.Any, None], ty.Generic[ty.AnyStr]):
 			#
 			# Note: `os.fwalk` support for binary paths was only added in 3.7+.
 			directory_str_or_fd = directory_str  # type: ty.Union[ty.AnyStr, int]
-			if HAVE_FWALK and (not isinstance(directory_str, bytes) or HAVE_FWALK_BYTES):  # type: ignore[unreachable]  # noqa: E501
+			if HAVE_FWALK and (not isinstance(directory_str, bytes) or HAVE_FWALK_BYTES):  # noqa: E501
 				self._close_fd = directory_str_or_fd = os.open(directory_str, os.O_RDONLY | O_DIRECTORY)
 			
 			self._generator = self._walk(
@@ -583,7 +583,7 @@ class walk(ty.Generator[FSNodeEntry, ty.Any, None], ty.Generic[ty.AnyStr]):
 	) -> ty.Generator[FSNodeEntry, ty.Any, None]:
 		if directory_str is not None:
 			sep = utils.maybe_fsencode(os.path.sep, directory_str)
-		elif matcher is not None and matcher.is_binary:  # type: ignore[unreachable]
+		elif matcher is not None and matcher.is_binary:
 			sep = os.fsencode(os.path.sep)  # type: ignore[assignment]
 		else:
 			sep = os.path.sep  # type: ignore[assignment]

--- a/test/functional/test_files.py
+++ b/test/functional/test_files.py
@@ -371,17 +371,17 @@ def test_add_recursive(client, cleanup_pins):
 
 
 def test_add_cid_version_0(client, cleanup_pins):
-    with tempfile.TemporaryDirectory() as empty_dir:
-        response = client.add(empty_dir, cid_version=0)
-        assert len(response) == 1
-        assert response[0]["Hash"] == "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
+	with tempfile.TemporaryDirectory() as empty_dir:
+		response = client.add(empty_dir, cid_version=0)
+		assert len(response) == 1
+		assert response[0]["Hash"] == "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
 
 
 def test_add_cid_version_1(client, cleanup_pins):
-    with tempfile.TemporaryDirectory() as empty_dir:
-        response = client.add(empty_dir, cid_version=1)
-        assert len(response) == 1
-        assert response[0]["Hash"] == "bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354"
+	with tempfile.TemporaryDirectory() as empty_dir:
+		response = client.add(empty_dir, cid_version=1)
+		assert len(response) == 1
+		assert response[0]["Hash"] == "bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354"
 
 
 @pytest.mark.dependency(depends=["test_add_recursive"])

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -173,15 +173,21 @@ try:
 				exclusions.append(r"\# pragma: http-backend=httpx")
 			
 			# Create temporary file with extended *coverage.py* configuration data
-			coveragerc.file.writelines(map(lambda s: s + "\n", itertools.chain((
-				"[run]",
-				"omit =",
-			), map(lambda s: "\t" + s, omitted_files),
-				(
-					"[report]",
-					"# Exclude lines specific to some other Python version from coverage",
-					"exclude_lines =",
-				), map(lambda s: "\t" + s, exclusions))))
+			coveragerc.file.writelines(
+				map(
+					lambda s: s + "\n",
+					itertools.chain(
+						(
+							"[run]",
+							"omit =",
+						),
+						map(lambda s: "\t" + s, omitted_files),
+						(
+							"[report]",
+							"# Exclude lines specific to some other Python version from coverage",
+							"exclude_lines =",
+						),
+						map(lambda s: "\t" + s, exclusions))))
 			coveragerc.file.flush()
 			
 			coverage_args = [

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -177,11 +177,11 @@ try:
 				"[run]",
 				"omit =",
 			), map(lambda s: "\t" + s, omitted_files),
-			(
-				"[report]",
-				"# Exclude lines specific to some other Python version from coverage",
-				"exclude_lines =",
-			), map(lambda s: "\t" + s, exclusions))))
+				(
+					"[report]",
+					"# Exclude lines specific to some other Python version from coverage",
+					"exclude_lines =",
+				), map(lambda s: "\t" + s, exclusions))))
 			coveragerc.file.flush()
 			
 			coverage_args = [

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -158,7 +158,7 @@ try:
 			else:
 				# Exclude the past
 				exclusions.append(r"\#PY2")
-				# Exclude code only used for compatiblity with a previous Python version
+				# Exclude code only used for compatibility with a previous Python version
 				exclusions.append(r"\#PY3({0})([^\d+]|$)".format(
 					"|".join(map(str, range(0, sys.version_info.minor)))
 				))

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ commands =
 
 
 [flake8]
-exclude = .git,.tox,+junk,coverage,dist,doc,*egg,build,tools,test/unit,docs,*__init__.py
+exclude = .git,.tox,+junk,coverage,dist,doc,*egg,build,tools,test/unit,docs,*__init__.py,venv
 
 # E221: Multiple spaces before operator
 # E241: Multiple spaces after ',': Breaks element alignment collections

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
 [testenv:py3-httpx]
 deps-exclusive =
 	httpx    (~= 0.14.0)
-	httpcore (~= 0.10.2)  # Has Unix domain socket support
+	httpcore (~= 0.10.2)
 deps =
 	{[testenv]deps}
 	{[testenv:py3-httpx]deps-exclusive}


### PR DESCRIPTION
1. Fix httpcore dependency by removing comment that broke pip
2. Add scripts to run tests and typing checks with Docker against multiple versions of Python

Previous to this change, attempts to run

    tox -e styleck -e typeck

..resulted in this error:

    ERROR: Invalid requirement: 'httpcore (~= 0.10.2)  # Has Unix domain socket support'

The error is caused by this part of that line being present in `tox.ini`:

    # Has Unix domain socket support

This commit does not fix the typing errors referenced in #255 but does demonstrate the typing errors now that the `httpcore` dependency is fixed.