### PR TITLE
Add scripts to verify compatibility with multiple Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ description-file = "README.md"
 #        `typing.NoReturn` function signature support. (Also, many other `typing` module
 #        items were only introduced post-release in 3.6 and version restrictions on these
 #	     versions ensure that those are all available as well.)
+#
+#        Maintain this concurrently with verify.sh
 requires-python = ">=3.6.2,!=3.7.0,!=3.7.1"
 requires = [
 	"multiaddr (>=0.0.7)",

--- a/tools/verify/Dockerfile
+++ b/tools/verify/Dockerfile
@@ -1,0 +1,15 @@
+ARG PYTHON_VERSION
+
+FROM python:${PYTHON_VERSION}
+
+RUN pip install --upgrade pip
+RUN pip install tox
+
+# Mount the source code here, instead of to /usr/src/app.
+# Otherwise, tox will fail due to folder being read-only.
+# Mount only the source code; avoid mounting working folders.
+
+RUN mkdir /source
+ADD entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tools/verify/Dockerfile
+++ b/tools/verify/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION
 
-FROM python:${PYTHON_VERSION}
+FROM python:${PYTHON_VERSION}-slim
 
 RUN pip install --upgrade pip
 RUN pip install tox

--- a/tools/verify/entrypoint.sh
+++ b/tools/verify/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cp -r /source/* /usr/src/app/
+
+exec $@
+

--- a/tools/verify/validate.sh
+++ b/tools/verify/validate.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+python_version=$1
+script_path=$(dirname $0)
+source=$(realpath "$script_path/../..")
+tag=py-ipfs-http-client-verify:$python_version
+
+pushd "$script_path"
+
+echo "Building validator for Python $python_version..."
+
+docker build --build-arg PYTHON_VERSION="$python_version" -t "$tag" .
+
+echo "Validating version $python_version"
+
+docker run \
+		-it \
+		-v "$source/docs":/source/docs:ro \
+		-v "$source/ipfshttpclient":/source/ipfshttpclient:ro \
+		-v "$source/test":/source/test:ro \
+		-v "$source/pyproject.toml":/source/pyproject.toml:ro \
+		-v "$source/README.md":/source/README.md:ro \
+		-v "$source/tox.ini":/source/tox.ini:ro \
+		-w /usr/src/app \
+		"$tag" \
+		tox -e styleck -e typeck
+
+popd
+

--- a/verify.sh
+++ b/verify.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+function validate() {
+	./tools/verify/validate.sh "$1"
+}
+
+if [ -z "$1" ]; then
+    echo "Validating minimum point release of each supported minor version..."
+
+    # Maintain this concurrently with [tool.flit.metadata].requires-python in pyproject.toml.
+    validate 3.6.2
+    validate 3.7.2
+    validate 3.8.0
+else
+    echo "Validating only $1..."
+    validate "$1"
+fi

--- a/verify.sh
+++ b/verify.sh
@@ -13,6 +13,7 @@ if [ -z "$1" ]; then
     validate 3.6.2
     validate 3.7.2
     validate 3.8.0
+    validate 3.9.0
 else
     echo "Validating only $1..."
     validate "$1"


### PR DESCRIPTION
Carved out of https://github.com/ipfs-shipyard/py-ipfs-http-client/pull/257

Adds scripts that use Docker to verify the library's compatibility with the versions of Python it supports.

With this change, the `travis` build will still fail with style linting and type linting errors. Change #257 will correct the style linting errors, and this change will be rebased once that one is merged.

Once #257 and this change are both merged, the scripts in this change will fail on the first Python version, `3.5.4`, because the current code base has syntax at https://github.com/ipfs-shipyard/py-ipfs-http-client/blob/52c1d2a28a43fb020d4d6375be2b8d432267c37d/ipfshttpclient/http_httpx.py#L48 that is not supported by `3.5.4` - this problem will be corrected by #258.