### PR TITLE
Update of „Change exceptions.VersionMismatch into warning“

### DIFF
--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -7,6 +7,7 @@ Classes:
 
 import os
 import typing as ty
+import warnings
 
 import multiaddr
 

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -65,12 +65,12 @@ def assert_version(version: str, minimum: str = VERSION_MINIMUM,
 	maximum = list(map(int, maximum.split('-', 1)[0].split('.')))
 
 	if minimum > version or version >= maximum:
-		raise exceptions.VersionMismatch(version, minimum, maximum)
-	
+		warnings.warn(exceptions.VersionMismatch(version, minimum, maximum))
+
 	for blacklisted in blacklist:
 		blacklisted = list(map(int, blacklisted.split('-', 1)[0].split('.')))
 		if version == blacklisted:
-			raise exceptions.VersionMismatch(version, minimum, maximum)
+			warnings.warn(exceptions.VersionMismatch(version, minimum, maximum))
 
 
 def connect(
@@ -96,7 +96,6 @@ def connect(
 	
 	Raises
 	------
-		~ipfshttpclient.exceptions.VersionMismatch
 		~ipfshttpclient.exceptions.ErrorResponse
 		~ipfshttpclient.exceptions.ConnectionError
 		~ipfshttpclient.exceptions.ProtocolError

--- a/ipfshttpclient/exceptions.py
+++ b/ipfshttpclient/exceptions.py
@@ -1,8 +1,10 @@
 """
 The class hierarchy for exceptions is:
 
+	Warning
+	 └── VersionMismatch
+
 	Error
-	 ├── VersionMismatch
 	 ├── AddressError
 	 ├── EncoderError
 	 │    ├── EncoderMissingError
@@ -38,7 +40,7 @@ class AddressError(Error, multiaddr.exceptions.Error):  # type: ignore[no-any-un
 		Error.__init__(self, "Unsupported Multiaddr pattern: {0!r}".format(addr))
 
 
-class VersionMismatch(Error):
+class VersionMismatch(Warning):
 	"""Raised when daemon version is not supported by this client version."""
 	__slots__ = ("current", "minimum", "maximum")
 	#current: ty.Sequence[int]

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -20,7 +20,7 @@ def is_available():  # noqa
 	if not isinstance(__is_available, bool):
 		try:
 			ipfshttpclient.connect()
-		except ipfshttpclient.exceptions.Error as error:
+		except ipfshttpclient.exceptions.Error:
 			__is_available = False
 		else:
 			__is_available = True

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -22,10 +22,6 @@ def is_available():  # noqa
 			ipfshttpclient.connect()
 		except ipfshttpclient.exceptions.Error as error:
 			__is_available = False
-			
-			# Make sure version incompatibility is displayed to users
-			if isinstance(error, ipfshttpclient.exceptions.VersionMismatch):
-				raise
 		else:
 			__is_available = True
 

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -1,23 +1,51 @@
+import warnings
+
 import pytest
 
 import ipfshttpclient
 
 
 def test_assert_version():
-	# Minimum required version
-	ipfshttpclient.assert_version("0.1.0", "0.1.0", "0.2.0", ["0.1.2"])
-	
+	with warnings.catch_warnings(record=True) as w:
+		# Cause all warnings to always be triggered.
+		warnings.simplefilter("always")
+
+		# Minimum required version
+		ipfshttpclient.assert_version("0.1.0", "0.1.0", "0.2.0", ["0.1.2"])
+
+		assert len(w) == 0
+
 	# Too high version
-	with pytest.raises(ipfshttpclient.exceptions.VersionMismatch):
+	with warnings.catch_warnings(record=True) as w:
+		# Cause all warnings to always be triggered.
+		warnings.simplefilter("always")
+
 		ipfshttpclient.assert_version("0.2.0", "0.1.0", "0.2.0", ["0.1.2"])
-	
+
+		assert len(w) == 1
+		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
+
+
 	# Too low version
-	with pytest.raises(ipfshttpclient.exceptions.VersionMismatch):
+	with warnings.catch_warnings(record=True) as w:
+		# Cause all warnings to always be triggered.
+		warnings.simplefilter("always")
+
 		ipfshttpclient.assert_version("0.0.5", "0.1.0", "0.2.0", ["0.1.2"])
-	
+
+		assert len(w) == 1
+		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
+
+
 	# Blacklisted version
-	with pytest.raises(ipfshttpclient.exceptions.VersionMismatch):
+	with warnings.catch_warnings(record=True) as w:
+		# Cause all warnings to always be triggered.
+		warnings.simplefilter("always")
+
 		ipfshttpclient.assert_version("0.1.2-1", "0.1.0", "0.2.0", ["0.1.2"])
+
+		assert len(w) == 1
+		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
 
 
 def test_client_session_param():

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -1,51 +1,26 @@
-import warnings
-
 import pytest
 
 import ipfshttpclient
 
 
 def test_assert_version():
-	with warnings.catch_warnings(record=True) as w:
-		# Cause all warnings to always be triggered.
-		warnings.simplefilter("always")
-
+	with pytest.warns(None) as warnings:
 		# Minimum required version
 		ipfshttpclient.assert_version("0.1.0", "0.1.0", "0.2.0", ["0.1.2"])
 
-		assert len(w) == 0
+	assert len(warnings) == 0
 
 	# Too high version
-	with warnings.catch_warnings(record=True) as w:
-		# Cause all warnings to always be triggered.
-		warnings.simplefilter("always")
-
+	with pytest.warns(ipfshttpclient.exceptions.VersionMismatch):
 		ipfshttpclient.assert_version("0.2.0", "0.1.0", "0.2.0", ["0.1.2"])
 
-		assert len(w) == 1
-		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
-
-
 	# Too low version
-	with warnings.catch_warnings(record=True) as w:
-		# Cause all warnings to always be triggered.
-		warnings.simplefilter("always")
-
+	with pytest.warns(ipfshttpclient.exceptions.VersionMismatch):
 		ipfshttpclient.assert_version("0.0.5", "0.1.0", "0.2.0", ["0.1.2"])
 
-		assert len(w) == 1
-		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
-
-
 	# Blacklisted version
-	with warnings.catch_warnings(record=True) as w:
-		# Cause all warnings to always be triggered.
-		warnings.simplefilter("always")
-
+	with pytest.warns(ipfshttpclient.exceptions.VersionMismatch):
 		ipfshttpclient.assert_version("0.1.2-1", "0.1.0", "0.2.0", ["0.1.2"])
-
-		assert len(w) == 1
-		assert issubclass(w[-1].category, ipfshttpclient.exceptions.VersionMismatch)
 
 
 def test_client_session_param():


### PR DESCRIPTION
Closes #253 by addressing the issue found during code review.

Once this is merged, I think we can finally release py-ipfs-http-client 0.8!