### PR TITLE
Print exception thrown while trying to connect to IPFS 

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -1,8 +1,10 @@
 # Note that this file is special in that py.test will automatically import this file and gather
 # its list of fixtures even if it is not directly imported into the corresponding test case.
-import pathlib
 
+import pathlib
 import pytest
+import sys
+import typing as ty
 
 import ipfshttpclient
 
@@ -15,57 +17,57 @@ def fake_dir() -> pathlib.Path:
 	return TEST_DIR.joinpath('fake_dir')
 
 
-__is_available = None
-def is_available():  # noqa
+@pytest.fixture(scope='session')
+def ipfs_is_available() -> bool:
 	"""
 	Return whether the IPFS daemon is reachable or not
 	"""
-	global __is_available
 
-	if not isinstance(__is_available, bool):
-		try:
-			ipfshttpclient.connect()
-		except ipfshttpclient.exceptions.Error:
-			__is_available = False
-		else:
-			__is_available = True
+	try:
+		with ipfshttpclient.connect():
+			pass
+	except ipfshttpclient.exceptions.Error as e:
+		print('\nFailed to connect to IPFS client', file=sys.stderr)
+		print(e, file=sys.stderr)
 
-	return __is_available
+		return False
+	else:
+		return True
 
 
 def sort_by_key(items, key="Name"):
 	return sorted(items, key=lambda x: x[key])
 
 
-def get_client(offline=False):
-	if is_available():
-		return ipfshttpclient.Client(offline=offline)
+def _generate_client(
+		ipfs_is_available: bool,
+		offline: bool
+) -> ty.Generator[ipfshttpclient.Client, None, None]:
+	if ipfs_is_available:
+		with ipfshttpclient.Client(offline=offline) as client:
+			yield client
 	else:
 		pytest.skip("Running IPFS node required")
 
 
 @pytest.fixture(scope="function")
-def client():
-	"""Create a client with function lifetimme to connect to the IPFS daemon.
-
-	Each test function should instantiate a fresh client, so use this
-	fixture in test functions."""
-	with get_client() as client:
-		yield client
+def client(ipfs_is_available):
+	yield from _generate_client(ipfs_is_available, False)
 
 
 @pytest.fixture(scope="function")
 def offline_client():
-	"""Create a client in offline mode with function lifetimme"""
-	with get_client(offline=True) as client:
-		yield client
+	yield from _generate_client(ipfs_is_available, True)
+
+
+@pytest.fixture(scope="module")
+def module_client():
+	yield from _generate_client(ipfs_is_available, False)
 
 
 @pytest.fixture(scope="module")
 def module_offline_client():
-	"""Create a client in offline mode with module lifetime."""
-	with get_client(offline=True) as client:
-		yield client
+	yield from _generate_client(ipfs_is_available, True)
 
 
 @pytest.fixture

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -51,22 +51,17 @@ def _generate_client(
 
 
 @pytest.fixture(scope="function")
-def client(ipfs_is_available):
+def client(ipfs_is_available: bool):
 	yield from _generate_client(ipfs_is_available, False)
 
 
 @pytest.fixture(scope="function")
-def offline_client():
+def offline_client(ipfs_is_available: bool):
 	yield from _generate_client(ipfs_is_available, True)
 
 
 @pytest.fixture(scope="module")
-def module_client():
-	yield from _generate_client(ipfs_is_available, False)
-
-
-@pytest.fixture(scope="module")
-def module_offline_client():
+def module_offline_client(ipfs_is_available: bool):
 	yield from _generate_client(ipfs_is_available, True)
 
 

--- a/test/functional/test_other.py
+++ b/test/functional/test_other.py
@@ -1,14 +1,12 @@
 import ipfshttpclient
 
-import conftest
 
-
-def test_ipfs_node_available():
+def test_ipfs_node_available(ipfs_is_available):
 	"""
 	Dummy test to ensure that running the tests without a daemon produces a failure, since we
 	think it's unlikely that people running tests want this
 	"""
-	assert conftest.is_available(), \
+	assert ipfs_is_available, \
 	       "Functional tests require an IPFS node to be available at: {0}" \
 	       .format(ipfshttpclient.DEFAULT_ADDR)
 


### PR DESCRIPTION
Inspired by #224 and the aggravation of the recent transient build failures connecting to the docker daemon, though that is a separate issue. It felt the same :@

* Print exception (on a double new line due to progress percentages)
* Refactor to use pytest fixtures instead of an evil evil `global` variable
* Remove some comments that restate `pytest` documentation about `fixture` scopes