### PR TITLE
Not accurate note statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ unmaintained and does not work with any recent go-IPFS version.
 
 **Note**: This library occasionally has to change to stay compatible with the IPFS HTTP API.
 Currently, this library is still under testing against [go-ipfs v0.8.0](https://github.com/ipfs/go-ipfs/releases/tag/v0.8.0).
-We strive to support the last 5 releases oftested go-IPFS at any given time; go-IPFS v0.5.0 therefore
+We strive to support the last 5 releases of go-IPFS at any given time; go-IPFS v0.5.0 therefore
 being to oldest supported version at this time.
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ See the [relevant section of the CHANGELOG](CHANGELOG.md#py-ipfs-http-client-041
 unmaintained and does not work with any recent go-IPFS version.
 
 **Note**: This library occasionally has to change to stay compatible with the IPFS HTTP API.
-Currently, this library is tested against [go-ipfs v0.8.0](https://github.com/ipfs/go-ipfs/releases/tag/v0.8.0).
-We strive to support the last 5 releases of go-IPFS at any given time; go-IPFS v0.5.0 therefore
+Currently, this library is still under testing against [go-ipfs v0.8.0](https://github.com/ipfs/go-ipfs/releases/tag/v0.8.0).
+We strive to support the last 5 releases oftested go-IPFS at any given time; go-IPFS v0.5.0 therefore
 being to oldest supported version at this time.
 
 ## Table of Contents


### PR DESCRIPTION
Hi, 
According to the second Note in the README documentation: 

> Note: This library occasionally has to change to stay compatible with the IPFS HTTP API. Currently, this library is tested against _go-ipfs v0.8.0_. We strive to support the last 5 releases of go-IPFS at any given time; go-IPFS v0.5.0 therefore being to oldest supported version at this time.

So from this line: 
> Currently, this library is tested against _go-ipfs v0.8.0_. 

I understood that's working successfully with _go-ipfs v0.8.0_, and when tried to connect found this issue here #275  and it's still doesn't support  _go-ipfs v0.8.0_ until resolving this issue #274 , also this issue has been first mentioned in issue #252 

So I've changed in this PR the above note statement to be more accurate from my point of view: 
> Note: This library occasionally has to change to stay compatible with the IPFS HTTP API. Currently, this library is still under testing against go-ipfs v0.8.0. We strive to support the last 5 releases oftested go-IPFS at any given time; go-IPFS v0.5.0 therefore being to oldest supported version at this time.

Maybe I misunderstood it from the first time but actually didn't find meaning other than it's working with v8.
Thanks. 