### PR TITLE
Replace pytest_ordering with pytest_order

### DIFF
--- a/test/functional/test_miscellaneous.py
+++ b/test/functional/test_miscellaneous.py
@@ -21,7 +21,7 @@ def test_id(client):
 # Shutdown test #
 #################
 
-@pytest.mark.last
+@pytest.mark.order("last")
 def test_daemon_stop(daemon, client):
 	# The value for the `daemon` “fixture” is injected using a pytest plugin
 	# with access to the created daemon subprocess object defined directly

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -107,7 +107,7 @@ try:
 		"localserver",
 		"pytest_cov",
 		"pytest_mock",
-		"pytest_ordering",
+		"pytest_order",
 	])
 	
 	with tempfile.NamedTemporaryFile("r+") as coveragerc:

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 	pytest-dependency  ~= 0.5
 	pytest-localserver ~= 0.5
 	pytest-mock        ~= 3.5
-	pytest-ordering    ~= 0.6
+	pytest-order       ~= 0.8
 	
 	pytest-cid ~= 1.1
 	py-cid
@@ -157,4 +157,4 @@ testpaths =
 	test/functional
 
 markers =
-    last: marker supplied by but not registered by pytest-ordering module
+    last: marker supplied by but not registered by pytest-order module

--- a/tox.ini
+++ b/tox.ini
@@ -155,6 +155,3 @@ testpaths =
 	ipfshttpclient
 	test/unit
 	test/functional
-
-markers =
-    last: marker supplied by but not registered by pytest-order module


### PR DESCRIPTION
pytest_ordering seems unmaintained as it hasn't been updated in two years: https://github.com/ftobia/pytest-ordering. It is also broken, at least in Nixpkgs: https://github.com/NixOS/nixpkgs/pull/122264.
pytest_order is a maintained and working fork.
I added a similar patch to Nixpkgs a while ago to make it work there: https://github.com/NixOS/nixpkgs/blob/6965eef223f491cc1d9289ce972d8ab6811a2d28/pkgs/development/python-modules/ipfshttpclient/default.nix#L59-L63. It would be nice to get rid of this patch for a future version.
I bumped the version in tox.ini a little since version 0.6 does not appear in https://pypi.org/project/pytest-order/#history.

I'm not sure if the line with `markers =` in tox.ini is still correct with this change, please check.