### PR TITLE
add optional arguments to add_str()

### DIFF
--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -241,9 +241,11 @@ class Client(files.Base, miscellaneous.Base):
 	@utils.return_field('Hash')
 	@base.returns_single_item(dict)
 	def add_bytes(self, data: bytes
-	        trickle: bool = False, only_hash: bool = False,
+	        trickle: bool = False, 
+		only_hash: bool = False,
 	        chunker: ty.Optional[str] = None,
-	        pin: bool = True, raw_leaves: bool = None,
+	        pin: bool = True, 
+		raw_leaves: bool = None,
 	        cid_version: ty.Optional[int] = None,
 	        **kwargs: base.CommonArgs):
 
@@ -303,9 +305,11 @@ class Client(files.Base, miscellaneous.Base):
 	@utils.return_field('Hash')
 	@base.returns_single_item(dict)
 	def add_str(self, string,
-	        trickle: bool = False, only_hash: bool = False,
+	        trickle: bool = False, 
+		only_hash: bool = False,
 	        chunker: ty.Optional[str] = None,
-	        pin: bool = True, raw_leaves: bool = None,
+	        pin: bool = True, 
+		raw_leaves: bool = None,
 	        cid_version: ty.Optional[int] = None,
 	        **kwargs: base.CommonArgs):
 

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -284,12 +284,12 @@ class Client(files.Base, miscellaneous.Base):
 				Hash of the added IPFS object
 		"""
 
-		opts = {
+		opts: ty.Dict[str, ty.Union[str, bool]] = {
 			"trickle": trickle,
 			"only-hash": only_hash,
 			"pin": pin,
 			"raw-leaves": raw_leaves if raw_leaves is not None else nocopy,
-		}  # type: ty.Dict[str, ty.Union[str, bool]]
+		}  
 		for option_name, option_value in [
 			("chunker", chunker),
 			("cid-version", cid_version),
@@ -348,12 +348,12 @@ class Client(files.Base, miscellaneous.Base):
 				Hash of the added IPFS object
 		"""
 
-		opts = {
+		opts: ty.Dict[str, ty.Union[str, bool]] = {
 			"trickle": trickle,
 			"only-hash": only_hash,
 			"pin": pin,
 			"raw-leaves": raw_leaves if raw_leaves is not None else nocopy,
-		}  # type: ty.Dict[str, ty.Union[str, bool]]
+		}  
 		for option_name, option_value in [
 			("chunker", chunker),
 			("cid-version", cid_version),

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -247,7 +247,7 @@ class Client(files.Base, miscellaneous.Base):
 	        pin: bool = True, 
 		raw_leaves: bool = None,
 	        cid_version: ty.Optional[int] = None,
-	        **kwargs: base.CommonArgs):
+	        **kwargs: base.CommonArgs) -> str:
 
 		"""Adds a set of bytes as a file to IPFS.
 
@@ -311,7 +311,7 @@ class Client(files.Base, miscellaneous.Base):
 	        pin: bool = True, 
 		raw_leaves: bool = None,
 	        cid_version: ty.Optional[int] = None,
-	        **kwargs: base.CommonArgs):
+	        **kwargs: base.CommonArgs) -> str:
 
 		"""Adds a Python string as a file to IPFS.
 
@@ -373,7 +373,7 @@ class Client(files.Base, miscellaneous.Base):
 	        pin: bool = True, 
 		raw_leaves: bool = None,
 	        cid_version: ty.Optional[int] = None,
-	        **kwargs: base.CommonArgs):
+	        **kwargs: base.CommonArgs) -> str:
 		"""Adds a json-serializable Python dict as a json file to IPFS.
 
 		.. code-block:: python

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -240,7 +240,7 @@ class Client(files.Base, miscellaneous.Base):
 	
 	@utils.return_field('Hash')
 	@base.returns_single_item(dict)
-	def add_bytes(self, data: bytes
+	def add_bytes(self, data: bytes,
 	        trickle: bool = False, 
 		only_hash: bool = False,
 	        chunker: ty.Optional[str] = None,

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -243,7 +243,7 @@ class Client(files.Base, miscellaneous.Base):
 	def add_bytes(self, data: bytes
 	        trickle: bool = False, only_hash: bool = False,
 	        chunker: ty.Optional[str] = None,
-	        pin: bool = True, raw_leaves: bool = None
+	        pin: bool = True, raw_leaves: bool = None,
 	        cid_version: ty.Optional[int] = None,
 	        **kwargs: base.CommonArgs):
 
@@ -305,7 +305,7 @@ class Client(files.Base, miscellaneous.Base):
 	def add_str(self, string,
 	        trickle: bool = False, only_hash: bool = False,
 	        chunker: ty.Optional[str] = None,
-	        pin: bool = True, raw_leaves: bool = None
+	        pin: bool = True, raw_leaves: bool = None,
 	        cid_version: ty.Optional[int] = None,
 	        **kwargs: base.CommonArgs):
 


### PR DESCRIPTION
Responding as per request on Matrix. I've added the optional arguments I think are relevant. If this looks good, I'm happy to add the same processing for `add_json` and `add_bytes`. 