### PR TITLE
fix ModuleNotFoundError after flit_core update to 3.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit-core >=2,<4"]
+requires = ["flit-core >=2,<3.7.0"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
fix #311 