### PR TITLE
Adjust test for Pytest 7+

### DIFF
--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -1,14 +1,15 @@
 import pytest
+import warnings
 
 import ipfshttpclient
 
 
 def test_assert_version():
-	with pytest.warns(None) as warnings:
+	with warnings.catch_warnings():
 		# Minimum required version
 		ipfshttpclient.assert_version("0.1.0", "0.1.0", "0.2.0", ["0.1.2"])
 
-	assert len(warnings) == 0
+	warnings.simplefilter("error")
 
 	# Too high version
 	with pytest.warns(ipfshttpclient.exceptions.VersionMismatch):

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ isolated_build = true
 
 [testenv]
 deps =
-	pytest     ~= 6.2
+	pytest     >= 7.0.0
 	pytest-cov ~= 2.11
 	pytest-dependency  ~= 0.5
 	pytest-localserver ~= 0.5


### PR DESCRIPTION
Pytest7 deprecated usage of pytest.warns(None). See the following GitHub issues/PRs:

* pytest-dev/pytest#8645
* pytest-dev/pytest#9404