### PR TITLE
Make add_bytes() work with raw blocks

### DIFF
--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -259,8 +259,9 @@ class Client(files.Base, miscellaneous.Base):
 				Hash of the added IPFS object
 		"""
 		body, headers = multipart.stream_bytes(data, chunk_size=self.chunk_size)
-		return self._client.request('/add', decoder='json',
-		                            data=body, headers=headers, **kwargs)
+		# MODIFIED 2025-01-21, was "'/add'"
+		return self._client.request('/add?cid-version=1&chunker=size-1048576',
+		                            decoder='json', data=body, headers=headers, **kwargs)
 
 	@utils.return_field('Hash')
 	@base.returns_single_item(dict)

--- a/ipfshttpclient/client/__init__.py
+++ b/ipfshttpclient/client/__init__.py
@@ -259,7 +259,14 @@ class Client(files.Base, miscellaneous.Base):
 				Hash of the added IPFS object
 		"""
 		body, headers = multipart.stream_bytes(data, chunk_size=self.chunk_size)
-		# MODIFIED 2025-01-21, was "'/add'"
+		return self._client.request('/add',
+		                            decoder='json', data=body, headers=headers, **kwargs)
+
+	@utils.return_field('Hash')
+	@base.returns_single_item(dict)
+	def add_raw_bytes(self, data: bytes, **kwargs):
+		# Same as add_bytes() but raw
+		body, headers = multipart.stream_bytes(data, chunk_size=self.chunk_size)
 		return self._client.request('/add?cid-version=1&chunker=size-1048576',
 		                            decoder='json', data=body, headers=headers, **kwargs)
 


### PR DESCRIPTION
It would be nice if add_bytes() had some more functionality. This pull request (PR) adds a bit more functionality to it. This adds function `add_raw_bytes()` which is basically `add_bytes()` except with this call to the HTTP/RPC API: `return self._client.request('/add?cid-version=1&chunker=size-1048576',`

It is worth explaining similar pull requests or issues here. Both of the following are more ambitious ideas which are like making parts of the code a Swiss Army Knife (for it to do many more things instead of the one/few things it currently does):

https://github.com/ipfs-shipyard/py-ipfs-http-client/issues/288 titled "add_str() and add() do not take the same optional parameters". Ideally, add(), add_str(), and add_bytes() would all have the maximum amount of optional arguments, or at least each one would be able to add raw blocks. #288 is a short thread.

https://github.com/ipfs-shipyard/py-ipfs-http-client/pull/287 titled "add optional arguments to add_str()". https://github.com/ipfs-shipyard/py-ipfs-http-client/pull/287/files looks great (I guess, didn't run personally that code)! Why was it not accepted!? @ntninja said "we'll probably complete this eventually." - that didn't happen. @ftyers seemed to get embarrassed and was shy and therefore closed the PR, so that kinda killed enthusiasm for it.

My motivation for writing this is partly this issue - https://github.com/oduwsdl/ipwb/issues/853 - however, I do think this generally beneficial. The code I request to be merged here is solid and it does work. It is simple and adds a bit more useful functionality, so I think it would pass automated tests. add() can add raw blocks, but why shouldn't add_bytes() also be able to do that? I think they're used in different contexts, like add() only works on file objects and add_bytes() only works on streams/stdin/pipe (non-file things).